### PR TITLE
Nowe tłumaczenie zmieniające kwalifikację czynu

### DIFF
--- a/catalogue_pl_2024.txt
+++ b/catalogue_pl_2024.txt
@@ -1917,7 +1917,7 @@ c)	Powtórzyć rzut z linii bocznej dla drużyny B po sygnale gwizdkiem sędzieg
 d)	Rzut wolny dla drużyny B.
 e)	Rzut karny dla drużyny B.
 f)	Bezpośrednia kara 2-minutowego wykluczenia dla A4.
-14.23	Drużyny A gra siedmioma zawodnikami w polu gry (pusta bramka). Sędziowie decyduje o faulu w ataku przeciwko zawodnikowi A7. B8 wchodzi w posiadanie piłki i jest gotowy wykonać rzut wolny, jako rzut bezpośredni na pustą bramkę. W trakcie wykonywania rzutu, ale zanim piłka opuściła jego rękę, jest wywrócony przez A7, który pcha go w plecy. Zaraz po tym, po prawidłowej zmianie z A2, bramkarz A16 zajmuje pozycję w polu bramkowym. Prawidłowa decyzja?
+14.23	Drużyny A gra siedmioma zawodnikami w polu gry (pusta bramka). Sędziowie decyduje o faulu w ataku przeciwko zawodnikowi A7. B8 wchodzi w posiadanie piłki i jest gotowy wykonać rzut wolny, jako rzut bezpośredni na pustą bramkę. W trakcie wykonywania rzutu, ale zanim piłka opuściła jego rękę, jest trzymany z tyłu i pociągnięty przez A7 tak, że częściowo traci kontrolę nad ciałem. Zaraz po tym, po prawidłowej zmianie z A2, bramkarz A16 zajmuje pozycję w polu bramkowym. Prawidłowa decyzja?
 a)	Kara progresywna dla A7.
 b)	2-minutowe wykluczenie dla A7.
 c)	Dyskwalifikacja dla A7 (czerwona kartka pokazana przez sędziów).


### PR DESCRIPTION
Wskutek nieprecyzyjnego tłumaczenia, "_wywrócenie poprzez pchnięcie w plecy_" sugeruje zastosowanie przepisu 8:5a (=> dyskwalifikacja), ponieważ zawodnik podczas wykonywania rzutu jest zupełnie nieprzygotowany na taką sytuację.

Natomiast "_trzymanie, pociągnięcie powodując częściową utratę kontroli_" jednoznacznie wskazuje na przepis 8:4b (=>wykluczenie), co wg klucza było zamysłem oryginalnej wersji.

Odniesienie do wersji angielskiej:
_14.23) WHITE team are in attack and play 7 against 6 with empty goal. The referees call for an offensive foul against WHITE 7. BLACK 8 gets possession of the ball and is ready to execute the free throw as an attempt to shoot the ball into the empty goal. While doing so and before the ball has left his hand, he is held and pulled down from behind by WHITE 7 in a way that he partially loses his body control. Shortly after that, goalkeeper WHITE 16 enters his goal area after a correct substitution with WHITE 2. What is the correct decision?_