### PR TITLE
Q8.24 Jednoznacznie wskazany powód wykluczenia

### DIFF
--- a/catalogue_pl_2024.txt
+++ b/catalogue_pl_2024.txt
@@ -1166,7 +1166,7 @@ b)	Osoba towarzysząca próbuje nakłonić zespół do przerwania meczu
 c)	Kiedy zawodnik wykonuje rzut karny w głowę bramkarza (bramkarz nie wykonuje żadnego ruchu w kierunku piłki)
 d)	Po decyzji sędziów zawodnik demonstracyjnie wyrzuca piłkę daleko w trybuny
 e)	Zawodnik poza boiskiem opluwa kibica
-8.24	Zawodnik A3 został ukarany 2-minutowym wykluczeniem i siedzi na ławce zmian. Kiedy rzut z linii bocznej wykonywany jest w pobliżu ławki zmian, A3 krzyczy na sędziów i ubliża im. Prawidłowa decyzja?
+8.24	Zawodnik A3 został ukarany 2-minutowym wykluczeniem za faul i siedzi na ławce zmian. Kiedy rzut z linii bocznej wykonywany jest w pobliżu ławki zmian, A3 krzyczy na sędziów i ubliża im. Prawidłowa decyzja?
 a)	2-minutowe wykluczenie dla A3
 b)	Dyskwalifikacja dla A3 bez opisu w protokole (czerwona kartka pokazana przez sędziów); drużyna A będzie grała na boisku w składzie pomniejszonym o 1 zawodnika przez 2 minuty
 c)	Drużyna A będzie grała na boisku w składzie pomniejszonym o 1 zawodnika przez 4 minuty


### PR DESCRIPTION
Występujące w języku angielskim "wykluczenie za faul" wskazuje, że miało to miejsce gdy piłka była w grze. Zatem wspomniany rzut z linii bocznej musi być wykonywany później, gdy wykluczenie już trwa. W obecnej wersji odpowiedź c) mogłaby być prawidłowa (jeśli wykluczenie zostałoby nałożone po przyznaniu ww. rzutu z linii bocznej) i wykluczałaby się z d). Klucz wskazuje odpowiedź d).

Odniesienie do wersji angielskiej:
_8.24) WHITE 3 has received a 2-minute suspension for a foul and is sitting on the substitution bench. During a throw-in near the bench, WHITE 3 shouts at the referees to insult them. Correct decision? a)	2-minutes suspension for WHITE 3
b)	Disqualification of WHITE 3 without written report (red card shown by the referees), which causes an immediate 2-minute reduction of WHITE team on the court c)	WHITE team reduced by 1 player on the court for 4 minutes d)	Disqualification for WHITE 3, written report (red and blue cards shown by the referees), which causes an immediate 2-minute reduction of WHITE team on the court_